### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "chromedriver-manager"
 description = "A Rust library for downloading and managing ChromeDrivers."
-homepage = "https://github.com/Sw1ndlers/ChromedriverManager"
+repository = "https://github.com/Sw1ndlers/ChromedriverManager"
 keywords = ["chromedriver", "thirtyfour"]
 license = "MIT"
 version = "0.3.3"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.